### PR TITLE
Drop unused tree-sitter submodule from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "tree-sitter"]
-	path = tree-sitter
-	url = https://github.com/ikatyang/tree-sitter
-	branch = v0.19.3-custom
 [submodule "yaml-test-suite"]
 	path = yaml-test-suite
 	url = https://github.com/yaml/yaml-test-suite


### PR DESCRIPTION
Fixes the flatpak build for Lapce.
See https://github.com/flatpak/flatpak-builder/issues/402#issuecomment-877774408 for a detailed explanation